### PR TITLE
Remove the experimental tasty-reader for scala 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ val sharedSettings = Seq(
            "-Ywarn-value-discard"
          )
        else if (scalaBinaryVersion.value.startsWith("2.13"))
-         List("-Werror", "-Wdead-code", "-Wunused", "-Wvalue-discard", "-Ytasty-reader")
+         List("-Werror", "-Wdead-code", "-Wunused", "-Wvalue-discard")
        else if (scalaBinaryVersion.value.startsWith("3"))
          List(
            "-explain",
@@ -214,6 +214,7 @@ val root = project
   .settings(sharedSettings)
   .settings(noPublish)
   .settings(
-    name := "calev-root"
+    name := "calev-root",
+    crossScalaVersions := Nil
   )
   .aggregate(coreJVM, coreJS, fs2JVM, fs2JS, doobieJVM, circeJVM, circeJS, akkaJVM)


### PR DESCRIPTION
The akka module is not published for scala 3. If the root project
defines all `crossScalaVersions` then the akka_2.13 subproject is
compiled against the core_3 subproject; but since the core also exists
for 2.13, this is not necessary. Setting the `crossScalaVersions` key
to `Nil` for the root project allows to remove the `-Ytasty-reader`
setting; sbt compiles the akka suproject against core_2.13.