### PR TITLE
Fix for DateTimeException: Invalid date 'FEBRUARY 31'

### DIFF
--- a/modules/core/src/main/scala/com/github/eikek/calev/internal/DefaultTrigger.scala
+++ b/modules/core/src/main/scala/com/github/eikek/calev/internal/DefaultTrigger.scala
@@ -90,8 +90,10 @@ object DefaultTrigger extends Trigger {
     }
 
   case class Date(year: Int, month: Int, day: Int) {
-    def toLocalDate: LocalDate =
-      LocalDate.of(year, month, day)
+    def toLocalDate: LocalDate = {
+      val lastDayOfMonth = YearMonth.of(year, month).atEndOfMonth().getDayOfMonth
+      LocalDate.of(year, month, math.min(day, lastDayOfMonth))
+    }
 
     def incYear: Date =
       Date(year + 1, month, day)

--- a/modules/core/src/main/scala/com/github/eikek/calev/internal/Trigger.scala
+++ b/modules/core/src/main/scala/com/github/eikek/calev/internal/Trigger.scala
@@ -12,6 +12,8 @@ trait Trigger {
   def next(ref: ZonedDateTime, ev: CalEvent): Option[ZonedDateTime]
 
   def nextRepeat(count: Int)(ref: ZonedDateTime, ev: CalEvent): List[ZonedDateTime] = {
+    require(count >= 0, "Repeat count cannot be negative")
+
     @annotation.tailrec
     def go(result: List[ZonedDateTime], cur: ZonedDateTime, i: Int): List[ZonedDateTime] =
       if (i == 0) result
@@ -23,5 +25,4 @@ trait Trigger {
 
     go(Nil, ref, count).reverse
   }
-
 }

--- a/modules/core/src/test/scala/com/github/eikek/calev/CalEventTest.scala
+++ b/modules/core/src/test/scala/com/github/eikek/calev/CalEventTest.scala
@@ -96,6 +96,16 @@ class CalEventTest extends FunSuite {
     assertEquals(next.toLocalTime, LocalTime.of(21, 10, 0))
   }
 
+  test("day after last January is not 31st February") {
+    val expression = CalEvent(AllWeekdays, date(All, 2.c, All), time(0 #/ 6, 0.c, 0.c))
+
+    val next = expression
+      .nextElapse(OffsetDateTime.parse("2024-01-31T18:00+01:00").toZonedDateTime)
+      .get
+
+    assertEquals(next, ZonedDateTime.parse("2024-02-01T00:00+01:00"))
+  }
+
   private def zdt(y: Int, month: Int, d: Int, h: Int, min: Int, sec: Int): ZonedDateTime =
     ZonedDateTime.of(LocalDate.of(y, month, d), LocalTime.of(h, min, sec), ZoneOffset.UTC)
 }


### PR DESCRIPTION
This PR fixes 2 issues in calev-core:

1. Prevents throwing DateTimeException: Invalid date 'FEBRUARY 31' :

    The following example

    ```scala
        val expression = CalEvent(AllWeekdays, date(All, 2.c, All), time(0 #/ 6, 0.c, 0.c))

        val next = expression
          .nextElapse(OffsetDateTime.parse("2024-01-31T18:00+01:00").toZonedDateTime)
          .get

        assertEquals(next, ZonedDateTime.parse("2024-02-01T00:00+01:00"))
    ```
    in the current library version, will throw
    
    ```scala
    java.time.DateTimeException: Invalid date 'FEBRUARY 31'
    
	    at java.base/java.time.LocalDate.create(LocalDate.java:459)
	    at java.base/java.time.LocalDate.of(LocalDate.java:275)
	    at com.github.eikek.calev.internal.DefaultTrigger$Date.toLocalDate(DefaultTrigger.scala:96)
	    at com.github.eikek.calev.internal.DefaultTrigger$Calc.maxValue(DefaultTrigger.scala:197)
	    at com.github.eikek.calev.internal.DefaultTrigger$Calc.atStartBelow(DefaultTrigger.scala:221)
	    at com.github.eikek.calev.internal.DefaultTrigger$Calc.atStartBelowCurrent(DefaultTrigger.scala:227)
	    at com.github.eikek.calev.internal.DefaultTrigger$.run(DefaultTrigger.scala:83)
	    at com.github.eikek.calev.internal.DefaultTrigger$.go$1(DefaultTrigger.scala:40)
	    at com.github.eikek.calev.internal.DefaultTrigger$.next(DefaultTrigger.scala:51)
	    at com.github.eikek.calev.CalEvent.nextElapse(CalEvent.scala:44)
	    at com.github.eikek.calev.CalEventTest.$anonfun$new$45(CalEventTest.scala:103)
	    at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
    
    ```

   Adding range check for the day field fixes that particular problem


2. Prevents application freeze when negative `count` is passed to `Trigger.nextRepeat()` by adding validation