### PR TITLE
Use Scala 3 LTS versions

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,3 +3,9 @@ updates.ignore = [
   { groupId = "com.typesafe.akka" },
   { groupId = "com.lightbend.akka" }
 ]
+
+updates.pin = [
+  # Scala 3.3 is a Lobg Term Support (LTS) version
+  # https://www.scala-lang.org/blog/2022/08/17/long-term-compatibility-plans.html
+  { groupId = "org.scala-lang", artifactId = "scala3-library", version = "3.3." }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import com.github.sbt.git.SbtGit.GitKeys
 
 val scala212 = "2.12.20"
 val scala213 = "2.13.16"
-val scala3 = "3.4.3"
+val scala3 = "3.3.5" // LTS
 
 val updateReadme = inputKey[Unit]("Update readme")
 


### PR DESCRIPTION
In this PR:

* Change Scala 3 version to latest LTS version `3.3.5` from `3.4.3` Next release.
* Pin Scala 3 version to LTS with Scala Steward

This PR closes https://github.com/eikek/calev/issues/689