### PR TITLE
take DST into account

### DIFF
--- a/modules/core/src/main/scala/com/github/eikek/calev/CalEvent.scala
+++ b/modules/core/src/main/scala/com/github/eikek/calev/CalEvent.scala
@@ -2,8 +2,6 @@ package com.github.eikek.calev
 
 import java.time._
 
-import scala.collection.immutable.Seq
-
 final case class CalEvent(
     weekday: WeekdayComponent,
     date: DateEvent,
@@ -11,16 +9,14 @@ final case class CalEvent(
     zone: Option[ZoneId] = None
 ) {
 
-  def contains(ts: Instant): Boolean =
-    contains(ts.atZone(zone.getOrElse(CalEvent.UTC)))
-
-  def contains(zdate: ZonedDateTime): Boolean = {
+  def contains(zdate: ZonedDateTime, dstOffsetHour: Int = 0): Boolean = {
     val zd = zone.map(z => zdate.withZoneSameInstant(z)).getOrElse(zdate)
+
     weekday.contains(Weekday.from(zd.getDayOfWeek)) &&
     date.year.contains(zd.getYear()) &&
     date.month.contains(zd.getMonth().getValue()) &&
     date.day.contains(zd.getDayOfMonth()) &&
-    time.hour.contains(zd.getHour()) &&
+    time.hour.contains(zd.getHour() - dstOffsetHour) &&
     time.minute.contains(zd.getMinute()) &&
     time.seconds.contains(zd.getSecond())
   }

--- a/modules/core/src/main/scala/com/github/eikek/calev/CalEvent.scala
+++ b/modules/core/src/main/scala/com/github/eikek/calev/CalEvent.scala
@@ -2,6 +2,8 @@ package com.github.eikek.calev
 
 import java.time._
 
+import scala.collection.immutable.Seq
+
 final case class CalEvent(
     weekday: WeekdayComponent,
     date: DateEvent,

--- a/modules/core/src/main/scala/com/github/eikek/calev/internal/DefaultTrigger.scala
+++ b/modules/core/src/main/scala/com/github/eikek/calev/internal/DefaultTrigger.scala
@@ -270,15 +270,22 @@ object DefaultTrigger extends Trigger {
   }
 
   object Calc {
+
+    private val HOUR_MILLIS = 3600000
+
     def init(dt: DateTime, ce: CalEvent, ref: ZonedDateTime): Calc = {
       val zd = dt.toZonedDateTime(ce.zone.getOrElse(CalEvent.UTC))
-      val dstOffsetHoursZd: Int = GregorianCalendar.from(zd).get(Calendar.DST_OFFSET) / 3600000
-      val dstOffsetHoursRef: Int = GregorianCalendar.from(ref).get(Calendar.DST_OFFSET) / 3600000
       val ndt =
-        if (ce.copy(weekday = WeekdayComponent.All).contains(zd, dstOffsetHoursZd - dstOffsetHoursRef)) dt.incSecond
+        if (ce.copy(weekday = WeekdayComponent.All).contains(zd, getDstOffsetHours(zd) - getDstOffsetHours(ref)))
+          dt.incSecond
         else dt
       Calc(Flag.Exact, ndt, DateTime.Pos.Sec, ce)
     }
+
+    private def getDstOffsetHours(zd: ZonedDateTime) = {
+      GregorianCalendar.from(zd).get(Calendar.DST_OFFSET) / HOUR_MILLIS
+    }
   }
+
 
 }

--- a/modules/core/src/test/scala/com/github/eikek/calev/CalEventTest.scala
+++ b/modules/core/src/test/scala/com/github/eikek/calev/CalEventTest.scala
@@ -68,7 +68,7 @@ class CalEventTest extends FunSuite {
     assertEquals(next.getNano, 0)
   }
 
-  test("nextElapse respects DST with ref before time change") {
+  test("nextElapse respects DST with ref before time change - DST start") {
     val ce = CalEvent.unsafe("Mon *-*-* 02:00:00 Europe/Warsaw")
     val ref = zdtInZone(2025, 3, 27, 2, 0, 0, ZoneId.of("Europe/Warsaw"))
     val next = ce.nextElapse(ref).get
@@ -77,7 +77,25 @@ class CalEventTest extends FunSuite {
     assertEquals(next.toLocalTime, LocalTime.of(2, 0, 0))
   }
 
-  test("nextElapse respects DST with ref at time change") {
+  test("nextElapse respects DST with ref before time change - in DST") {
+    val ce = CalEvent.unsafe("Mon *-*-* 02:00:00 Europe/Warsaw")
+    val ref = zdtInZone(2025, 4, 27, 2, 0, 0, ZoneId.of("Europe/Warsaw"))
+    val next = ce.nextElapse(ref).get
+    assertEquals(next.getZone.getId, "Europe/Warsaw")
+    assertEquals(next.toLocalDate, LocalDate.of(2025, 4, 28))
+    assertEquals(next.toLocalTime, LocalTime.of(2, 0, 0))
+  }
+
+  test("nextElapse respects DST with ref before time change - DST end") {
+    val ce = CalEvent.unsafe("Mon *-*-* 03:00:00 Europe/Warsaw")
+    val ref = zdtInZone(2025, 10, 24, 3, 0, 0, ZoneId.of("Europe/Warsaw"))
+    val next = ce.nextElapse(ref).get
+    assertEquals(next.getZone.getId, "Europe/Warsaw")
+    assertEquals(next.toLocalDate, LocalDate.of(2025, 10, 27))
+    assertEquals(next.toLocalTime, LocalTime.of(3, 0, 0))
+  }
+
+  test("nextElapse respects DST with ref at time change - DST start") {
     val ce = CalEvent.unsafe("Sun *-*-* 02:00:00 Europe/Warsaw")
     val ref = zdtInZone(2025, 3, 30, 2, 0, 0, ZoneId.of("Europe/Warsaw"))
     val next = ce.nextElapse(ref).get
@@ -86,8 +104,18 @@ class CalEventTest extends FunSuite {
     assertEquals(next.toLocalTime, LocalTime.of(2, 0, 0))
   }
 
+  test("nextElapse respects DST with ref at time change - DST end") {
+    val ce = CalEvent.unsafe("Sun *-*-* 03:00:00 Europe/Warsaw")
+    val ref = zdtInZone(2025, 10, 26, 3, 0, 0, ZoneId.of("Europe/Warsaw"))
+    val next = ce.nextElapse(ref).get
+    assertEquals(next.getZone.getId, "Europe/Warsaw")
+    assertEquals(next.toLocalDate, LocalDate.of(2025, 11, 2))
+    assertEquals(next.toLocalTime, LocalTime.of(3, 0, 0))
+  }
 
-  test("nextElapse respects DST with ref before time change and CalEvent exactly at time change") {
+  test(
+    "nextElapse respects DST with ref before time change and CalEvent exactly at time change - DST start"
+  ) {
     val ce = CalEvent.unsafe("Sun *-*-* 02:00:00 Europe/Warsaw")
     val ref = zdtInZone(2025, 3, 27, 2, 0, 0, ZoneId.of("Europe/Warsaw"))
     val next = ce.nextElapse(ref).get
@@ -96,7 +124,18 @@ class CalEventTest extends FunSuite {
     assertEquals(next.toLocalTime, LocalTime.of(3, 0, 0))
   }
 
-  test("nextElapse respects DST with ref after time change") {
+  test(
+    "nextElapse respects DST with ref before time change and CalEvent exactly at time change - DST end"
+  ) {
+    val ce = CalEvent.unsafe("Sun *-*-* 03:00:00 Europe/Warsaw")
+    val ref = zdtInZone(2025, 10, 23, 3, 0, 0, ZoneId.of("Europe/Warsaw"))
+    val next = ce.nextElapse(ref).get
+    assertEquals(next.getZone.getId, "Europe/Warsaw")
+    assertEquals(next.toLocalDate, LocalDate.of(2025, 10, 26))
+    assertEquals(next.toLocalTime, LocalTime.of(3, 0, 0))
+  }
+
+  test("nextElapse respects DST with ref after time change - DST start") {
     val ce = CalEvent.unsafe("Sun *-*-* 02:00:00 Europe/Warsaw")
     val ref = zdtInZone(2025, 4, 20, 2, 0, 0, ZoneId.of("Europe/Warsaw"))
     val next = ce.nextElapse(ref).get
@@ -205,6 +244,14 @@ class CalEventTest extends FunSuite {
   private def zdt(y: Int, month: Int, d: Int, h: Int, min: Int, sec: Int): ZonedDateTime =
     ZonedDateTime.of(LocalDate.of(y, month, d), LocalTime.of(h, min, sec), ZoneOffset.UTC)
 
-  private def zdtInZone(y: Int, month: Int, d: Int, h: Int, min: Int, sec: Int, zone: ZoneId): ZonedDateTime =
+  private def zdtInZone(
+      y: Int,
+      month: Int,
+      d: Int,
+      h: Int,
+      min: Int,
+      sec: Int,
+      zone: ZoneId
+  ): ZonedDateTime =
     ZonedDateTime.of(LocalDate.of(y, month, d), LocalTime.of(h, min, sec), zone)
 }


### PR DESCRIPTION
At next elapse at DST time change nextElapse() enters the endless loop due to directly comparing ZDT hours not takin into account DST offset change, this fixes that